### PR TITLE
Fix typos and wording in documentation and script

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Welcome to the Flex Script for the Stellaris Mod "[More Picks & Points: Traits|C
 The server mode streamlines the setup process for multiplayer sessions, making it easy to share custom settings with friends:
 
 1. **Set Up Your Settings:** First, configure your Flex Script settings (follow the Customization Usage tips above) to your preference in NORMAL mode (or other than SERVER mode).
-2. **Prepare Server Mode:** Convert your Flex Script into a server-ready version throught the Flex Script Menu (select "SERVER MODE"). This process adjusts the script to work efficiently for multiplayer sessions.
+2. **Prepare Server Mode:** Convert your Flex Script into a server-ready version through the Flex Script Menu (select "SERVER MODE"). This process adjusts the script to work efficiently for multiplayer sessions.
 3. **Share with Friends:** Distribute the server-ready Flex Script executable (`flexScript.exe`) and the corresponding settings file (`fs_settings.json`) to your friends.
 4. **Easy Client Setup:** Your friends should place both the executable and the settings file anywhere in the same directory on their system.
 5. **Run and Play:** Have your friends run the `flexScript.exe`. The script will automatically configure their game using the shared settings, ensuring everyone is synchronized for multiplayer gameplay. 

--- a/flexScript.py
+++ b/flexScript.py
@@ -80,7 +80,7 @@ p_settings = ["settings", "config", "configuration file", "fs_settings"]
 print_tut = ["print_tutorial", "print tutorial", "p_tutorial", "p tutorial"]
 
 
-## Delcare headers
+## Declare headers
 header = f"""
 ##################################################
 #                                                #
@@ -395,7 +395,7 @@ def find_game_folder(history=None):
                         break
                     
                     elif path_conf in p_manual or path_conf == "3":                             # Manually apply folder
-                        game_directory = insert_path_manually("Stellaris installation", "\"C:/Program Files (x86)/Steam/steamapps/common/Stellaris/\"", "Please ensure you have provided the correct path.", "stellaris.exe")  # 1st var: Content  \\ 2nd var: PATH  \\ 3rd var: Exception error alert  \\ 4rd var: confirmation_file which can be Stellaris exe file f.ex.
+                        game_directory = insert_path_manually("Stellaris installation", "\"C:/Program Files (x86)/Steam/steamapps/common/Stellaris/\"", "Please ensure you have provided the correct path.", "stellaris.exe")  # 1st var: Content  \\ 2nd var: PATH  \\ 3rd var: Exception error alert  \\ 4th var: confirmation_file which can be Stellaris exe file f.ex.
                         separator_timer(1)
                         if game_directory == "cancel" or game_directory == None:
                             game_directory == None
@@ -430,7 +430,7 @@ def find_game_folder(history=None):
                         return game_directory
                         
                     elif prompt in p_manual or prompt in p_no or prompt in ["other", "2"]:
-                        game_directory = insert_path_manually("Stellaris installation", "\"C:/Program Files (x86)/Steam/steamapps/common/Stellaris/\"", "Please ensure you have provided the correct path.", "stellaris.exe")  # 1st var: Content  \\ 2nd var: PATH  \\ 3rd var: Exception error alert  \\ 4rd var: confirmation_file which can be Stellaris exe file f.ex.
+                        game_directory = insert_path_manually("Stellaris installation", "\"C:/Program Files (x86)/Steam/steamapps/common/Stellaris/\"", "Please ensure you have provided the correct path.", "stellaris.exe")  # 1st var: Content  \\ 2nd var: PATH  \\ 3rd var: Exception error alert  \\ 4th var: confirmation_file which can be Stellaris exe file f.ex.
                         separator_timer(1)
                         if game_directory == "cancel" or game_directory == None:
                             game_directory == None
@@ -524,7 +524,7 @@ def find_mod_folder(history=None):
                         break
                     
                     elif path_conf in p_manual or path_conf == "3":                             # Manually apply folder                      
-                        mod_directory = insert_path_manually("Steamapps -> Workshop -> Content folder", "\"C:/Program Files (x86)/Steam/steamapps/workshop/content/", "Please ensure you have provided the correct \"Steam\" / \"steamapps/\" \"workshop/\" \"content/\" path.\nThis is not to insert the MPP's Mod path directly\nBut to point where the stellaris workshop mods are located.", confirmation_folder).strip()  # 1st var: Content  \\ 2nd var: PATH  \\ 3rd var: Exception error alert  \\ 4rd var: confirmation_file which can be Stellaris MPP folder f.ex.
+                        mod_directory = insert_path_manually("Steamapps -> Workshop -> Content folder", "\"C:/Program Files (x86)/Steam/steamapps/workshop/content/", "Please ensure you have provided the correct \"Steam\" / \"steamapps/\" \"workshop/\" \"content/\" path.\nThis is not to insert the MPP's Mod path directly\nBut to point where the stellaris workshop mods are located.", confirmation_folder).strip()  # 1st var: Content  \\ 2nd var: PATH  \\ 3rd var: Exception error alert  \\ 4th var: confirmation_file which can be Stellaris MPP folder f.ex.
                         separator_timer(1)
                         if mod_directory == "cancel":
                             mod_directory == None
@@ -628,7 +628,7 @@ def find_mod_folder(history=None):
                             return mod_directory
                             
                         elif prompt in p_manual or prompt in p_no or prompt in ["other", "2"]:
-                            mod_directory = insert_path_manually("Steamapps -> Workshop -> Content folder", "\"C:/Program Files (x86)/Steam/steamapps/workshop/content/", "Please ensure you have provided the correct \"Steam\" / \"steamapps/\" \"workshop/\" \"content/\" path.\nThis is not to insert the MPP's Mod path directly\nBut to point where the stellaris workshop mods are located.", confirmation_folder).strip()  # 1st var: Content  \\ 2nd var: PATH  \\ 3rd var: Exception error alert  \\ 4rd var: confirmation_file which can be Stellaris MPP folder f.ex.
+                            mod_directory = insert_path_manually("Steamapps -> Workshop -> Content folder", "\"C:/Program Files (x86)/Steam/steamapps/workshop/content/", "Please ensure you have provided the correct \"Steam\" / \"steamapps/\" \"workshop/\" \"content/\" path.\nThis is not to insert the MPP's Mod path directly\nBut to point where the stellaris workshop mods are located.", confirmation_folder).strip()  # 1st var: Content  \\ 2nd var: PATH  \\ 3rd var: Exception error alert  \\ 4th var: confirmation_file which can be Stellaris MPP folder f.ex.
                             separator_timer(1)
                             if mod_directory == "cancel" or mod_directory == None:
                                 mod_directory == None
@@ -1320,7 +1320,7 @@ def reset(prompt):
 def shutdown(prompt):
     if prompt in p_quit:
         separator_timer(1)
-        print("### SHUTING DOWN! ###")
+        print("### SHUTTING DOWN! ###")
         separator_timer(1)
         print("### See ya! I hope FLEX SCRIPT helped you!")
         custom_sleep(3)


### PR DESCRIPTION
## Summary
- Correct spelling in server mode instructions
- Clean up script comments and shutdown message

## Testing
- `codespell -q 3 --skip=flexScript.spec`
- `python -m py_compile flexScript.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0b3f94ec08324ae7119a398e9e60a