### PR TITLE
Add autocompile batch script for flexScript

### DIFF
--- a/autocompile.bat
+++ b/autocompile.bat
@@ -1,0 +1,26 @@
+@echo off
+setlocal enabledelayedexpansion
+
+REM Automatically compile any flexScript* Python file into flexScripy.exe
+
+set SCRIPT=
+for %%i in (flexScript*.py) do (
+    set SCRIPT=%%i
+)
+
+if not defined SCRIPT (
+    echo No flexScript*.py file found.
+    exit /b 1
+)
+
+where pyinstaller >nul 2>nul
+if errorlevel 1 (
+    echo PyInstaller not found. Install it with:
+    echo     pip install pyinstaller
+    exit /b 1
+)
+
+pyinstaller --noconfirm --onefile --name flexScripy "!SCRIPT!"
+
+echo.
+echo Build complete. The executable can be found in the dist folder.


### PR DESCRIPTION
## Summary
- Add `autocompile.bat` to compile the `flexScript` Python script into `flexScripy.exe` using PyInstaller.

## Testing
- `python -m py_compile flexScript.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0d0d117ec8324b25c9704dc2889ab