### PR TITLE
Add autocompile batch script for flexScript

### DIFF
--- a/autocompile.bat
+++ b/autocompile.bat
@@ -1,0 +1,40 @@
+@echo off
+setlocal enabledelayedexpansion
+
+REM Automatically compile any flexScript* Python file into flexScripy.exe
+
+set SCRIPT=
+for %%i in (flexScript*.py) do (
+    set SCRIPT=%%i
+)
+
+if not defined SCRIPT (
+    echo No flexScript*.py file found.
+    goto end
+)
+
+where pyinstaller >nul 2>nul
+if errorlevel 1 (
+    echo PyInstaller not found. Installing...
+    python -m pip install --quiet pyinstaller
+    if errorlevel 1 (
+        echo Failed to install PyInstaller. Install it manually with:
+        echo     pip install pyinstaller
+        goto end
+    )
+)
+
+pyinstaller --noconfirm --onefile --name flexScripy "!SCRIPT!"
+
+if errorlevel 1 (
+    echo.
+    echo Build failed.
+    goto end
+)
+
+echo.
+echo Build complete. The executable can be found in the dist folder.
+
+:end
+echo.
+pause


### PR DESCRIPTION
## Summary
- Ensure `autocompile.bat` stays open after running and auto-installs PyInstaller if missing

## Testing
- `python -m py_compile flexScript.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0d0d117ec8324b25c9704dc2889ab